### PR TITLE
updating error log with struct hierarchy

### DIFF
--- a/cmd/iso20022/main.go
+++ b/cmd/iso20022/main.go
@@ -64,7 +64,13 @@ var Validate = &cobra.Command{
 			return err
 		}
 
-		return doc.Validate()
+		err = doc.Validate()
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("the iso20022 (" + doc.NameSpace() + ") message is valid")
+		return nil
 	},
 }
 

--- a/pkg/utils/validate.go
+++ b/pkg/utils/validate.go
@@ -5,16 +5,26 @@
 package utils
 
 import (
-	"fmt"
+	"errors"
 	"reflect"
+	"strings"
 
 	"encoding/xml"
 )
 
 var (
 	DefaultValidateFunction = "Validate"
-	debug                   = false
 )
+
+func getTypeName(value string) string {
+	values := strings.Split(value, ".")
+	if len(values) > 1 {
+		values := strings.Split(values[1], " ")
+		return values[0]
+	} else {
+		return values[0]
+	}
+}
 
 func validateCallbackByValue(data reflect.Value) error {
 	method := data.MethodByName(DefaultValidateFunction)
@@ -23,8 +33,15 @@ func validateCallbackByValue(data reflect.Value) error {
 		if len(response) > 0 {
 			err := response[0]
 			if !err.IsNil() {
-				if debug {
-					fmt.Println(data.String() + ": " + method.String())
+				typeName := getTypeName(data.String())
+				if len(typeName) > 0 {
+					errStr := err.Interface().(error).Error()
+					if !strings.Contains(errStr, ")") {
+						errStr = errStr + " (" + typeName + ")"
+					} else {
+						errStr = errStr[:len(errStr)-1] + ", " + typeName + ")"
+					}
+					return errors.New(errStr)
 				}
 				return err.Interface().(error)
 			}


### PR DESCRIPTION
example:

./iso20022 validator --input test/testdata/valid_auth_v02_error.xml
Error: The value of Max15NumericText is invalid (CurrencyControlHeader4, ContractRegistrationRequestV02)

./iso20022 validator --input test/testdata/valid_auth_v02.xml
the iso20022 (urn:iso:std:iso:20022:tech:xsd:auth.018.001.02) message is valid