### PR TITLE
cutomize datatime format

### DIFF
--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -686,18 +686,18 @@ func _unmarshalTime(text []byte, t *time.Time, format string) (err error) {
 }
 
 const (
-	DefaultTimeFormat = "2006-01-02T15:04:05.999999999"
+	DefaultDateTimeFormat = "2006-01-02T15:04:05.999999999"
 )
 
-var TimeFormatString = DefaultTimeFormat
+var DateTimeFormatString = DefaultDateTimeFormat
 
 type xsdDateTime time.Time
 
 func (t *xsdDateTime) UnmarshalText(text []byte) error {
-	return _unmarshalTime(text, (*time.Time)(t), TimeFormatString)
+	return _unmarshalTime(text, (*time.Time)(t), DateTimeFormatString)
 }
 func (t xsdDateTime) MarshalText() ([]byte, error) {
-	return []byte((time.Time)(t).Format(TimeFormatString)), nil
+	return []byte((time.Time)(t).Format(DateTimeFormatString)), nil
 }
 func (t xsdDateTime) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if (time.Time)(t).IsZero() {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -685,13 +685,19 @@ func _unmarshalTime(text []byte, t *time.Time, format string) (err error) {
 	return err
 }
 
+const (
+	DefaultTimeFormat = "2006-01-02T15:04:05.999999999"
+)
+
+var TimeFormatString = DefaultTimeFormat
+
 type xsdDateTime time.Time
 
 func (t *xsdDateTime) UnmarshalText(text []byte) error {
-	return _unmarshalTime(text, (*time.Time)(t), "2006-01-02T15:04:05.999999999")
+	return _unmarshalTime(text, (*time.Time)(t), TimeFormatString)
 }
 func (t xsdDateTime) MarshalText() ([]byte, error) {
-	return []byte((time.Time)(t).Format("2006-01-02T15:04:05.999999999")), nil
+	return []byte((time.Time)(t).Format(TimeFormatString)), nil
 }
 func (t xsdDateTime) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if (time.Time)(t).IsZero() {


### PR DESCRIPTION
Datetime format is defined in "XML Schema Part 2: Datatypes Second Edition - W3C Recommendation 28 October 2004" which is aligned with ISO 8601
UTC time format, local time with UTC offset format, or local time format

But some specification based on iso 20022 used a bit different format
example: the date of RTP is required to be set to Eastern Time (ET)

So added global variable of datetime format in package


